### PR TITLE
 removed trailing slash from rpc url

### DIFF
--- a/EthereumKit/Networking/JSONRPC/HTTPJSONRPCRequest.swift
+++ b/EthereumKit/Networking/JSONRPC/HTTPJSONRPCRequest.swift
@@ -18,7 +18,7 @@ public struct HTTPJSONRPCRequest<Batch: JSONRPCBatchType>: RequestType {
     }
     
     public var path: String {
-        return "/"
+        return ""
     }
     
     public var parameters: Any? {


### PR DESCRIPTION
Hey, what was the reason behind adding a trailing slash to every JSON RPC request?

This removes trailing slash from the JSON RPC requests because otherwise, INFURA treats the request as an error.